### PR TITLE
Sort the cut list returned by listcuts

### DIFF
--- a/cutbucket/cuts.py
+++ b/cutbucket/cuts.py
@@ -237,7 +237,7 @@ class CutUtils(object):
         else:
             for file in files:
                 allcuts.append(file.split('/')[-1].split('.')[0])
-            return allcuts
+            return sorted(allcuts)
 
         
     def loadcut(self, name, lgccurrent = True):


### PR DESCRIPTION
This adds the sorting of the cuts that are returned by `CutUtils.listcuts`, which makes it easier to find cuts in the returned list by eye.

Resolves #5.