### PR TITLE
Change order of where dirs are made in init

### DIFF
--- a/cutbucket/cuts.py
+++ b/cutbucket/cuts.py
@@ -92,18 +92,17 @@ class CutUtils(object):
         self.relativepath = relativepath
         self.fullpath = repopath + self.relativepath
 
-
-        if not os.path.isdir(f'{self.fullpath}/current_cuts'):
-            print(f'folder: {self.relativepath}/current_cuts/ does not exist, it is being created now')
-            os.makedirs(f'{self.fullpath}/current_cuts')
-        if not os.path.isdir(f'{self.fullpath}/archived_cuts'):
-            print(f'folder: {self.relativepath}/archived_cuts/ does not exist, it is being created now')
-            os.makedirs(f'{self.fullpath}/archived_cuts')
-        if lgcsync:  
+         if lgcsync:  
             print('Connecting to GitHub Repository, please ensure that your ssh keys have been uploaded to GitHub account')
             self.repo = git.Repo(repopath)
             try:
                 self.repo.git.checkout(self.branch)
+                if not os.path.isdir(f'{self.fullpath}/current_cuts'):
+                    print(f'folder: {self.relativepath}/current_cuts/ does not exist, it is being created now')
+                    os.makedirs(f'{self.fullpath}/current_cuts')
+                if not os.path.isdir(f'{self.fullpath}/archived_cuts'):
+                    print(f'folder: {self.relativepath}/archived_cuts/ does not exist, it is being created now')
+                    os.makedirs(f'{self.fullpath}/archived_cuts')
             except:
                  raise GitError(f'Unable to connect to branch {self.branch}')
         else:


### PR DESCRIPTION
Changed the order of where the directories are made in the initialization of the CutUtils class. This makes it so that they are only made if we were able to connect to the repo and the folders do not exist yet. Resolves #9.